### PR TITLE
[Bugfix, #91] test now passes

### DIFF
--- a/services/user.service.spec.ts
+++ b/services/user.service.spec.ts
@@ -13,12 +13,12 @@ describe('UserService', () => {
                         return user;
                     },
                 },
-            });
+            }, 'models');
             const UserService = proxyquire('./user.service', {
                 '../models': mockModels,
             });
 
-            const result = await UserService.getUserById(user.username);
+            const result = await UserService.UserService.getUserById(user.username);
             expect(result, 'user object').to.not.be.undefined;
         });
     });

--- a/services/user.service.ts
+++ b/services/user.service.ts
@@ -4,7 +4,7 @@ const models = require("../models");
 export namespace UserService {
   export async function getUserById(userId: number): Promise<any> {
     try {
-      const user = await models.user.findOne({
+      const user = await models.User.findOne({
         where: {
           userId: userId
         }


### PR DESCRIPTION
I found three errors in your app.

1. In `services/user.service.ts` `user` should have been `User`
2. In the test, as you did not have a `.sequelizerc` file and your `models` are not in the default location, you need to tell `makeMockModels` where to find the models. (I will update the readme in `sequelize-test-helpers` to make that clearer)
3. For some reason (I don't know Typescript very well sorry) when you export your `namespace` it exports as property of the module, so instead of `UserService.getUserById` you need to refer to `UserService.UserService.getUserById`.

If interested you can read my article on why JS developers should not use TypeScript

* part 1 https://itnext.io/dont-do-this-part-one-objects-and-their-misuse-bd0771c3178a
* part 2 https://itnext.io/dont-do-this-part-two-the-trouble-with-typescript-8ea9b26892e2

Cheers

Dave
